### PR TITLE
fixing wrapLine feature

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -81,6 +81,7 @@ function wrapLinesInSpan(codeTree, lineStyle) {
     const newLines = getNewLines(value);
     if (newLines) {
       const splitValue = value.split('\n');
+      const className = node.properties.className;
       splitValue.forEach((text, i) => {
         const lineNumber = newTree.length + 1;
         const newChild = { type: 'text', value: `${text}\n`};
@@ -88,16 +89,19 @@ function wrapLinesInSpan(codeTree, lineStyle) {
           const children = tree.slice(
             lastLineBreakIndex + 1, 
             index
-          ).concat(newChild);
+          )
           newTree.push(createLineElement({ children, lineNumber, lineStyle })); 
-        } else if (i === splitValue.length - 1) {
+          newTree.push(createLineElement({ children:[newChild], lineNumber, lineStyle, className})); 
+      } else if (i === splitValue.length - 1) {
           const stringChild = (
             tree[index + 1] && 
             tree[index + 1].children && 
             tree[index + 1].children[0]
           );
           if (stringChild) {
-            stringChild.value = `${text}${stringChild.value}`;
+            const lastLineInPreviousSpan = { type: 'text', value: `${text}`};
+            const newElem = createLineElement({ children: [lastLineInPreviousSpan], lineNumber, lineStyle, className});
+            tree.splice(index + 1, 0, newElem);
           } else {
             newTree.push(createLineElement({ children: [newChild], lineNumber, lineStyle })); 
           }


### PR DESCRIPTION
![fix](https://cloud.githubusercontent.com/assets/4451461/26225994/7da7c572-3c32-11e7-85da-41bc677598e6.png)
wrapLine didn't work well when span had line breaks in it